### PR TITLE
fix: removes university regex as not all universities have university…

### DIFF
--- a/src/app/apply/_steps/types.ts
+++ b/src/app/apply/_steps/types.ts
@@ -26,11 +26,7 @@ export const UserFormSchema = z.object({
   universityYear: z.string().min(1, "Please select your year of study"),
   universityEmail: z
     .string()
-    .email("Please enter a valid email address")
-    .regex(
-      /\.edu$|\.ac\.|\.edu\.|university|college/i,
-      "Please use your university email address"
-    ),
+    .email("Please enter a valid email address"),
   verificationCode: z.string().optional(),
   codeSent: z.boolean(),
   authFlow: z.enum(["signup", "signin"]).optional(),


### PR DESCRIPTION
I've removed the regex for university emails because, as evidenced in the JSON for universities other than the university I study at, not every university has a .ac.uk or .edu or otherwise domain. For example, my university (BPP University) has forcefully assigned a @my.bpp.com email to every student, despite them owning a .ac.uk domain, and when I emailed them to enquire why this was and to push them to give every student a .ac.uk email, they refused. So in edgecases like these, using a regex to validate a university email prevents legitimate university students who were not fortunate enough to be assigned an actual university gTLD from signing up.